### PR TITLE
feat: expose `source_docs_path`

### DIFF
--- a/docs/customisation/sidebar.rst
+++ b/docs/customisation/sidebar.rst
@@ -94,6 +94,7 @@ configuration. Simply add the following to your Sphinx ``conf.py`` file:
         "source_type": "github|gitlab|bitbucket",
         "source_user": "<username>",
         "source_repo": "<repository>",
+        "source_docs_path": "/docs/",  # Optional
     }
 
 With this configuration, Shibuya will automatically include an "Edit This Page" link in


### PR DESCRIPTION
I am not storing sources into the `docs` folder, and so "Edit this page ->" link was not working.
As I had to check the code to know how to change the "docs" path, I think it would be interesting to show it in the documentation.