### PR TITLE
docs: add mermaid theming section

### DIFF
--- a/docs/extensions/mermaid.rst
+++ b/docs/extensions/mermaid.rst
@@ -63,6 +63,21 @@ It adds a ``mermaid`` directive to embed mermaid markup. For example:
       John->Bob: How about you?
       Bob-->John: Jolly good!
 
+Theming
+-------
+
+To theme your diagrams you can use ``mermaid_init_js`` setting:
+
+.. code-block:: python
+
+  mermaid_init_js = """
+  mermaid.initialize({theme:"forest"});
+  """
+
+You can find all the options here: `mermaid.js.org/config/schema-docs/config.html`_.
+
+To see the python configuration options checkout: `https://github.com/mgaitan/sphinxcontrib-mermaid?tab=readme-ov-file#config-values`_.
+
 Mermaid not working
 -------------------
 


### PR DESCRIPTION
This solution has been taken from the discussion at https://github.com/lepture/shibuya/discussions/36, and I think it's a common enough issue to be in the documentation.