### PR TITLE
DOC: Update doc to include LinkedIn simpleicon info after #43

### DIFF
--- a/docs/customisation/icons.rst
+++ b/docs/customisation/icons.rst
@@ -52,6 +52,7 @@ for social networks. These icons include:
 - YouTube: ``--simpleicons-youtube-url``
 - X (Twitter): ``--simpleicons-x-twitter-url``
 - Reddit: ``--simpleicons-reddit-url``
+- LinkedIn: ``--simpleicons-linkedin-url``
 
 Custom Icons
 ------------


### PR DESCRIPTION
I forgot to document the new LinkedIn simpleicon option in #43 . 