### PR TITLE
feat: add toctree_maxdepth option to specify depth shown in sidebar

### DIFF
--- a/docs/contributing/index.rst
+++ b/docs/contributing/index.rst
@@ -71,7 +71,7 @@ server with:
 
 .. code-block:: shell
 
-    python server.py
+    python serve.py
 
 Build static
 ~~~~~~~~~~~~

--- a/docs/customisation/sidebar.rst
+++ b/docs/customisation/sidebar.rst
@@ -24,6 +24,7 @@ The above configuration will only expand the first level of the global table of 
 Shibuya sphinx theme also provides other options to control the toctree_ function:
 
 - toctree_collapse: equals to ``collapse``, ``False`` by default.
+- toctree_maxdepth: equals to ``maxdepth``, ``4`` by default.
 - toctree_titles_only: equals to ``titles_only``, ``True`` by default
 - toctree_includehidden: equals to ``includehidden``, ``True`` by default
 

--- a/src/shibuya/theme/shibuya/layout/default.html
+++ b/src/shibuya/theme/shibuya/layout/default.html
@@ -20,7 +20,7 @@
       <div class="sy-scrollbar p-6">
         {%- include "partials/globaltoc-above.html" %}
         <div class="globaltoc" data-expand-depth="{{ theme_globaltoc_expand_depth }}">
-          {%- set globaltoc = toctree(collapse=theme_toctree_collapse, titles_only=theme_toctree_titles_only, includehidden=theme_toctree_includehidden) -%}
+          {%- set globaltoc = toctree(collapse=theme_toctree_collapse, titles_only=theme_toctree_titles_only, includehidden=theme_toctree_includehidden, maxdepth=theme_navigation_depth) -%}
           {{ expandtoc(globaltoc, theme_globaltoc_expand_depth) }}
         </div>
       </div>

--- a/src/shibuya/theme/shibuya/layout/default.html
+++ b/src/shibuya/theme/shibuya/layout/default.html
@@ -20,7 +20,7 @@
       <div class="sy-scrollbar p-6">
         {%- include "partials/globaltoc-above.html" %}
         <div class="globaltoc" data-expand-depth="{{ theme_globaltoc_expand_depth }}">
-          {%- set globaltoc = toctree(collapse=theme_toctree_collapse, titles_only=theme_toctree_titles_only, includehidden=theme_toctree_includehidden, maxdepth=theme_navigation_depth) -%}
+          {%- set globaltoc = toctree(collapse=theme_toctree_collapse, maxdepth=theme_toctree_maxdepth, titles_only=theme_toctree_titles_only, includehidden=theme_toctree_includehidden) -%}
           {{ expandtoc(globaltoc, theme_globaltoc_expand_depth) }}
         </div>
       </div>

--- a/src/shibuya/theme/shibuya/theme.conf
+++ b/src/shibuya/theme/shibuya/theme.conf
@@ -29,9 +29,9 @@ nav_links_align =
 
 # default global toc collapse
 toctree_collapse =
+toctree_maxdepth = 4
 toctree_titles_only = True
 toctree_includehidden = True
-navigation_depth = 4
 globaltoc_expand_depth = 0
 
 # social links

--- a/src/shibuya/theme/shibuya/theme.conf
+++ b/src/shibuya/theme/shibuya/theme.conf
@@ -31,6 +31,7 @@ nav_links_align =
 toctree_collapse =
 toctree_titles_only = True
 toctree_includehidden = True
+navigation_depth = 4
 globaltoc_expand_depth = 0
 
 # social links


### PR DESCRIPTION
Added new toctree_maxdepth option to specify depth shown in sidebar, this fixes #65.
I used the [readthedocs theme](https://sphinx-rtd-theme.readthedocs.io/en/stable/configuring.html#confval-navigation_depth) as reference.
