### PR TITLE
fix: skip prompt when selecting code

### DIFF
--- a/static/css/contents/code.css
+++ b/static/css/contents/code.css
@@ -35,10 +35,14 @@ pre.literal-block {
   font-family: "Twemoji Country Flags", var(--sy-f-mono);
 }
 
+.highlight .gp,
+.highlight .linenos {
+  user-select: none;
+}
+
 .highlight .linenos {
   display: inline-block;
   box-shadow: -0.05rem 0 var(--syntax-linenos-divider) inset;
-  user-select: none;
   margin-right: .8rem;
   padding-right: .8rem;
   opacity: 0.6;


### PR DESCRIPTION
I wanted to mimic what was done in https://github.com/sphinx-doc/sphinx/pull/9120, so that prompts are no more part of the selected text.

Note: I also added those lines to my `conf.py` file in order to have the same effect when copying the code:

```python
# sphinx-copybutton (content to be skipped when copying)
#   - .linenos is the Sphinx default for line numbers
#   - .gp is the Pygments class for the prompts
#   - .go is the class for console outputs
copybutton_exclude = ".linenos, .gp, .go"
```