### PR TITLE
fix: add `super()` to `extrahead` in all layouts

### DIFF
--- a/src/shibuya/theme/shibuya/layout/404.html
+++ b/src/shibuya/theme/shibuya/layout/404.html
@@ -1,6 +1,7 @@
 {%- extends "layout.html" -%}
 
 {% block extrahead %}
+{{ super() }}
 <style>
   .not-found {
     padding-top: calc(30vh - var(--sy-s-offset-top));

--- a/src/shibuya/theme/shibuya/layout/compact.html
+++ b/src/shibuya/theme/shibuya/layout/compact.html
@@ -1,6 +1,7 @@
 {%- extends "base.html" -%}
 
 {%- block extrahead -%}
+  {{ super() }}
   {% include "components/meta-opengraph.html" %}
   {% include "components/alternate-links.html" %}
 {%- endblock -%}

--- a/src/shibuya/theme/shibuya/layout/default.html
+++ b/src/shibuya/theme/shibuya/layout/default.html
@@ -1,6 +1,7 @@
 {%- extends "base.html" -%}
 
 {%- block extrahead -%}
+  {{ super() }}
   {% include "components/meta-opengraph.html" %}
   {% include "components/alternate-links.html" %}
 {%- endblock -%}

--- a/src/shibuya/theme/shibuya/layout/landing.html
+++ b/src/shibuya/theme/shibuya/layout/landing.html
@@ -1,6 +1,7 @@
 {%- extends "layout.html" -%}
 
 {%- block extrahead %}
+  {{ super() }}
   {% include "components/meta-opengraph.html" %}
 {%- endblock %}
 

--- a/src/shibuya/theme/shibuya/layout/simple.html
+++ b/src/shibuya/theme/shibuya/layout/simple.html
@@ -1,6 +1,7 @@
 {%- extends "layout.html" -%}
 
 {%- block extrahead %}
+  {{ super() }}
   {% include "components/meta-opengraph.html" %}
   {% include "components/alternate-links.html" %}
 {%- endblock %}


### PR DESCRIPTION
Ensure every `layout/xxx.html` template preserves inherited head content by appending `super()` in the `extrahead` block.

This change prevents layout-level extrahead overrides from dropping scripts/styles injected by parent templates (for example, custom scripts added in `docs/_templates/base.html`), so head injections are consistently applied across all pages.

Close: #120 