### PR TITLE
Fix condition check for social links fields

### DIFF
--- a/src/shibuya/_social_links.py
+++ b/src/shibuya/_social_links.py
@@ -51,7 +51,7 @@ def patch_social_context(context: Dict[str, Any]) -> None:
 
 def _fix_social_links(context: Dict[str, Any], key: Literal["theme_nav_socials", "theme_foot_socials"]):
     fields = context.get(key)
-    if not fields:
+    if not fields and not isinstance(fields, list):
         fields = DEFAULT_SOCIALS[key]
 
     for data in fields:


### PR DESCRIPTION
Allow empty social links in theme options:

~~~toml
html_theme_options = {
    "nav_socials": []
}
~~~

Currently, shibuya adds default social links. With the patch, it displays nothing.
