### PR TITLE
Update link styles in yue.css

### DIFF
--- a/static/css/contents/yue.css
+++ b/static/css/contents/yue.css
@@ -39,13 +39,14 @@
 .yue a {
   color: var(--yue-c-link-1);
   font-weight: 500;
-  text-decoration: none;
-  border-bottom: 1px solid var(--yue-c-link-border);
+  text-decoration: underline;
+  text-decoration-color: var(--yue-c-link-border);
+  text-decoration-thickness: 1px;
 }
 
 .yue a:hover {
   color: var(--yue-c-link-2);
-  border-bottom-width: 2px;
+  text-decoration-thickness: 2px;
 }
 
 .yue pre {


### PR DESCRIPTION
Currently, the version of shibuya add a border on image that are a link:

~~~markdown
[![Dora's signatory](/_images/Dorabadge1.png)](https://sfdora.org/)
~~~