### PR TITLE
fix: show breadcrumbs in desktop layout

### DIFF
--- a/static/css/layout/breadcrumbs.css
+++ b/static/css/layout/breadcrumbs.css
@@ -39,7 +39,7 @@
 
 @media (min-width: 1280px) {
   .sy-breadcrumbs {
-    display: none;
+    padding: 0 3rem;
   }
 }
 


### PR DESCRIPTION
Drop the `display: none` rule that hides breadcrumbs at the `min-width: 1280px` breakpoint, and align their left edge with the main content by adding `padding: 0 3rem` at the same breakpoint.

Close: #134 