### PR TITLE
feat: animate globaltoc expand/collapse

### DIFF
--- a/static/css/layout/globaltoc.css
+++ b/static/css/layout/globaltoc.css
@@ -33,6 +33,10 @@
 .globaltoc li > ul {
   margin-left: 0.6rem;
   font-size: 0.96rem;
+  max-height: 0;
+  overflow: hidden;
+  visibility: hidden;
+  transition: max-height 0.3s ease, visibility 0.3s ease;
 }
 
 .globaltoc li.toctree-l1 > ul {
@@ -95,17 +99,18 @@
 
 .globaltoc li.current > ul,
 .globaltoc li._expand > ul {
-  display: block;
+  max-height: 1000px;
+  visibility: visible;
 }
 
-.globaltoc li > ul,
 .globaltoc li._collapse > ul {
-  display: none;
+  max-height: 0;
+  visibility: hidden;
 }
 
 .globaltoc li > button > i {
   transform: rotate(0deg);
-  transition: transform 0.2s ease;
+  transition: transform 0.3s ease;
 }
 
 .globaltoc li.current > button > i,

--- a/static/js/globaltoc.js
+++ b/static/js/globaltoc.js
@@ -25,8 +25,10 @@ function addToggleToc () {
     const list = el.parentNode
     if (list.classList.contains('current') || shouldExpand(list)) {
       list.classList.add('_expand')
+      el.style.maxHeight = el.scrollHeight + "px"
     } else {
       list.classList.add('_collapse')
+      el.style.maxHeight = "0px"
     }
     const button = createToggleButton(el)
     list.appendChild(button)
@@ -55,9 +57,11 @@ function createToggleButton (el) {
     if (list.classList.contains("_expand")) {
       list.classList.remove("_expand")
       list.classList.add("_collapse")
+      el.style.maxHeight = "0px"
     } else {
       list.classList.remove("_collapse")
       list.classList.add("_expand")
+      el.style.maxHeight = el.scrollHeight + "px"
     }
     updateArialLabel()
   }


### PR DESCRIPTION
Animate the sidebar globaltoc sublists when toggling the chevron icon, replacing the instant `display` switch with a smooth height transition:

- Animate sublists with a 0.3s `max-height`/`visibility` transition, keeping collapsed items out of the tab order in `globaltoc.css`.
- Set inline `max-height` from each sublist's `scrollHeight` so expand and collapse animate symmetrically in `globaltoc.js`.
- Sync the chevron rotation duration to 0.3s to match the animation.