### PR TITLE
feat: make nav links collapsible in mobile layout

### DIFF
--- a/src/shibuya/theme/shibuya/components/nav-links.html
+++ b/src/shibuya/theme/shibuya/components/nav-links.html
@@ -11,17 +11,21 @@
     {%- if link.children %}
       <li class="link">
         {%- if link.url -%}
-          <a class="js-menu" href="{{ expandURL(link.url, link.resource) }}" id="nav-trigger-{{ loop.index }}" aria-controls="nav-children-{{ loop.index }}">
-            <span>{{ link.title }}</span>
-            <i class="i-lucide chevron-down"></i>
-          </a>
+          <div class="link-row">
+            <a href="{{ expandURL(link.url, link.resource) }}">
+              <span>{{ link.title }}</span>
+            </a>
+            <button class="js-menu" type="button" id="nav-trigger-{{ loop.index }}" aria-controls="nav-children-{{ loop.index }}" aria-expanded="false" aria-label="{{ link.title }}">
+              <i class="i-lucide chevron-down"></i>
+            </button>
+          </div>
         {%- else -%}
-          <button class="js-menu" type="button" id="nav-trigger-{{ loop.index }}" aria-controls="nav-children-{{ loop.index }}">
+          <button class="js-menu" type="button" id="nav-trigger-{{ loop.index }}" aria-controls="nav-children-{{ loop.index }}" aria-expanded="false">
             <span>{{ link.title }}</span>
             <i class="i-lucide chevron-down"></i>
           </button>
         {%- endif %}
-        <ul id="nav-children-{{ loop.index }}" aria-labelledby="nav-trigger-{{ loop.index }}">
+        <ul id="nav-children-{{ loop.index }}" aria-labelledby="nav-trigger-{{ loop.index }}" aria-hidden="true">
           {%- for item in link.children -%}
             {%- if item.summary -%}
               <li><a href="{{ expandURL(item.url, item.resource) }}">

--- a/static/css/layout/head.css
+++ b/static/css/layout/head.css
@@ -166,12 +166,58 @@
     margin: 0.5rem 0;
   }
 
-  .sy-head-links .link i.chevron {
-    display: none;
+  .sy-head-links .link > a,
+  .sy-head-links .link > button,
+  .sy-head-links .link > .link-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    column-gap: 0.5rem;
+    width: 100%;
+    box-sizing: border-box;
+  }
+
+  .sy-head-links .link > .link-row > a {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .sy-head-links .link > .js-menu,
+  .sy-head-links .link > .link-row {
+    border-radius: 6px;
+    transition: background-color 0.2s;
+  }
+
+  .sy-head-links .link > .js-menu[aria-expanded="true"],
+  .sy-head-links .link > .link-row:has(.js-menu[aria-expanded="true"]) {
+    background-color: var(--sy-c-surface);
+  }
+
+  .sy-head-links .link > .link-row:has(.js-menu[aria-expanded="true"]) > button {
+    align-self: stretch;
+    display: flex;
+    align-items: center;
+    border-left: 1px solid var(--sy-c-divider);
+  }
+
+  .sy-head-links .link i.chevron-down {
+    display: inline-block;
+    transition: transform 0.2s ease;
+    transform: rotate(-90deg);
+  }
+
+  .sy-head-links .link > .js-menu[aria-expanded="true"] i.chevron-down,
+  .sy-head-links .link > .link-row:has(.js-menu[aria-expanded="true"]) i.chevron-down {
+    transform: rotate(0deg);
   }
 
   .sy-head-links .link > ul {
+    display: none;
     margin: 0.5rem 0 0.5rem 1rem;
+  }
+
+  .sy-head-links .link > ul[aria-hidden="false"] {
+    display: block;
   }
 
   .sy-head-extra form.searchbox {
@@ -223,11 +269,26 @@
     height: var(--sy-s-navbar-height);
   }
 
+  .sy-head-links .link > .link-row {
+    display: flex;
+    align-items: center;
+    border-radius: 6px;
+    padding: 0 0.5rem;
+    column-gap: 0.25rem;
+  }
+
+  .sy-head-links .link > .link-row > a,
+  .sy-head-links .link > .link-row > button {
+    padding-left: 0;
+    padding-right: 0;
+  }
+
   .sy-head-links a:hover {
     color: var(--sy-c-link-hover);
   }
 
-  .sy-head-links .link:hover > a {
+  .sy-head-links .link:hover > a,
+  .sy-head-links .link:hover > .link-row {
     background-color: var(--sy-c-surface);
     border-radius: 6px;
   }


### PR DESCRIPTION
- Collapse parent/children nav links by default on mobile and allow them to be toggled open/closed.
- When a parent has a `url`, render the title as a link that navigates and the chevron as a separate toggle for the children.
- When a parent has no `url`, keep the title and chevron as a single toggle that expands/collapses the children.
- Polish mobile nav links styling: full-width rows, chevron rotation, expanded rounded highlight, and a divider between label and chevron.