### PR TITLE
docs(extensions): use list-table for project information

### DIFF
--- a/docs/extensions/click-extra.rst
+++ b/docs/extensions/click-extra.rst
@@ -5,8 +5,12 @@ click-extra
 
 Adding ``click-extra`` support for Sphinx.
 
-- **Documentation**: https://kdeldycke.github.io/click-extra/sphinx.html
-- **Source Code**: https://github.com/kdeldycke/click-extra
+.. list-table:: Project Information
+
+  * - **Documentation**
+    - https://kdeldycke.github.io/click-extra/sphinx.html
+  * - **Source Code**
+    - https://github.com/kdeldycke/click-extra
 
 Usage
 -----

--- a/docs/extensions/docsearch.rst
+++ b/docs/extensions/docsearch.rst
@@ -7,8 +7,12 @@ sphinx-docsearch
 
 ``sphinx-docsearch`` replaces Sphinx's built-in search with Algolia DocSearch.
 
-- **Documentation**: https://sphinx-docsearch.readthedocs.io/
-- **Source Code**: https://github.com/algolia/sphinx-docsearch
+.. list-table:: Project Information
+
+  * - **Documentation**
+    - https://sphinx-docsearch.readthedocs.io/
+  * - **Source Code**
+    - https://github.com/algolia/sphinx-docsearch
 
 Install
 -------

--- a/docs/extensions/jupyter-sphinx.rst
+++ b/docs/extensions/jupyter-sphinx.rst
@@ -8,8 +8,12 @@ jupyter-sphinx
 Jupyter-sphinx is a Sphinx extension that executes embedded code
 in a Jupyter kernel, and embeds outputs of that code in the document.
 
-- **Documentation**: https://jupyter-sphinx.readthedocs.io/
-- **Source Code**: https://github.com/jupyter/jupyter-sphinx
+.. list-table:: Project Information
+
+  * - **Documentation**
+    - https://jupyter-sphinx.readthedocs.io/
+  * - **Source Code**
+    - https://github.com/jupyter/jupyter-sphinx
 
 Install
 -------

--- a/docs/extensions/mermaid.rst
+++ b/docs/extensions/mermaid.rst
@@ -8,8 +8,12 @@ sphinxcontrib-mermaid
 This extension allows you to embed Mermaid graphs in your documents,
 including general flowcharts, sequence diagrams, gantt diagrams and more.
 
-- **Documentation**: https://sphinxcontrib-mermaid-demo.readthedocs.io/
-- **Source Code**: https://github.com/mgaitan/sphinxcontrib-mermaid
+.. list-table:: Project Information
+
+  * - **Documentation**
+    - https://sphinxcontrib-mermaid-demo.readthedocs.io/
+  * - **Source Code**
+    - https://github.com/mgaitan/sphinxcontrib-mermaid
 
 Install
 -------

--- a/docs/extensions/nbsphinx.ipynb
+++ b/docs/extensions/nbsphinx.ipynb
@@ -3,17 +3,25 @@
   {
    "cell_type": "raw",
    "metadata": {
-    "raw_mimetype": "text/restructuredtext"
+    "raw_mimetype": "text/restructuredtext",
+    "vscode": {
+     "languageId": "raw"
+    }
    },
    "source": [
-    ".. _nbsphinx:\n\n",
+    ".. _nbsphinx:\n",
+    "\n",
     "nbsphinx\n",
     "========\n",
     "\n",
     "``nbsphinx`` is a Sphinx extension that provides a source parser for ``*.ipynb`` files.\n",
     "\n",
-    "- **Documentation**: https://nbsphinx.readthedocs.io/\n",
-    "- **Source Code**: https://github.com/spatialaudio/nbsphinx\n"
+    ".. list-table:: Project Information\n",
+    "\n",
+    "  * - **Documentation**\n",
+    "    - https://nbsphinx.readthedocs.io/\n",
+    "  * - **Source Code**\n",
+    "    - https://github.com/spatialaudio/nbsphinx"
    ]
   },
   {
@@ -326,8 +334,8 @@
     "ANSI Colors\n",
     "~~~~~~~~~~~\n",
     "\n",
-    "The standard output and standard error streams may contain ",
-    "`ANSI escape sequences <https://en.wikipedia.org/wiki/ANSI_escape_code>`_ ",
+    "The standard output and standard error streams may contain \n",
+    "`ANSI escape sequences <https://en.wikipedia.org/wiki/ANSI_escape_code>`_ \n",
     "to change the text and background colors."
    ]
   },

--- a/docs/extensions/numpydoc.rst
+++ b/docs/extensions/numpydoc.rst
@@ -7,8 +7,12 @@ numpydoc
 
 Numpy's Sphinx extensions to power Numpy's docstring syntax.
 
-- **Documentation**: https://numpydoc.readthedocs.io/
-- **Source Code**: https://github.com/numpy/numpydoc
+.. list-table:: Project Information
+
+  * - **Documentation**
+    - https://numpydoc.readthedocs.io/
+  * - **Source Code**
+    - https://github.com/numpy/numpydoc
 
 Install
 -------

--- a/docs/extensions/sphinx-autoapi.rst
+++ b/docs/extensions/sphinx-autoapi.rst
@@ -7,8 +7,12 @@ Sphinx AutoAPI is a Sphinx extension for generating complete API
 documentation without needing to load, run, or import the project
 being documented.
 
-- **Documentation**: https://sphinx-autoapi.readthedocs.io/
-- **Source Code**: https://github.com/readthedocs/sphinx-autoapi
+.. list-table:: Project Information
+
+  * - **Documentation**
+    - https://sphinx-autoapi.readthedocs.io/
+  * - **Source Code**
+    - https://github.com/readthedocs/sphinx-autoapi
 
 Usage
 -----

--- a/docs/extensions/sphinx-click.rst
+++ b/docs/extensions/sphinx-click.rst
@@ -6,8 +6,12 @@ sphinx-click
 sphinx-click is a Sphinx plugin that allows you to automatically extract documentation
 from a click-based application and include it in your docs.
 
-- **Documentation**: https://sphinx-click.readthedocs.io/
-- **Source Code**: https://github.com/click-contrib/sphinx-click
+.. list-table:: Project Information
+
+  * - **Documentation**
+    - https://sphinx-click.readthedocs.io/
+  * - **Source Code**
+    - https://github.com/click-contrib/sphinx-click
 
 Usage
 -----

--- a/docs/extensions/sphinx-contributors.rst
+++ b/docs/extensions/sphinx-contributors.rst
@@ -5,8 +5,12 @@ sphinx-contributors
 
 Sphinx extension that helps you recognize the people who have contributed to an open-source project.
 
-- **Documentation**: https://sphinx-contributors.readthedocs.io/
-- **Source Code**: https://github.com/dgarcia360/sphinx-contributors
+.. list-table:: Project Information
+
+  * - **Documentation**
+    - https://sphinx-contributors.readthedocs.io/
+  * - **Source Code**
+    - https://github.com/dgarcia360/sphinx-contributors
 
 Usage
 -----

--- a/docs/extensions/sphinx-copybutton.rst
+++ b/docs/extensions/sphinx-copybutton.rst
@@ -8,8 +8,12 @@ sphinx-copybutton
 Add a little “copy” button to the right of your code blocks. This extension
 is maintained by Executable Books.
 
-- **Documentation**: https://sphinx-copybutton.readthedocs.io/
-- **Source Code**: https://github.com/executablebooks/sphinx-copybutton
+.. list-table:: Project Information
+
+  * - **Documentation**
+    - https://sphinx-copybutton.readthedocs.io/
+  * - **Source Code**
+    - https://github.com/executablebooks/sphinx-copybutton
 
 Install
 -------

--- a/docs/extensions/sphinx-datatables.rst
+++ b/docs/extensions/sphinx-datatables.rst
@@ -5,8 +5,12 @@ sphinx-datatables
 
 This extension makes it easy to use more expressive tables in Sphinx documentation with DataTables.
 
-- **Documentation**: https://sharm294.github.io/sphinx-datatables/
-- **Source Code**: https://github.com/sharm294/sphinx-datatables/
+.. list-table:: Project Information
+
+  * - **Documentation**
+    - https://sharm294.github.io/sphinx-datatables/
+  * - **Source Code**
+    - https://github.com/sharm294/sphinx-datatables/
 
 Usage
 -----

--- a/docs/extensions/sphinx-design.rst
+++ b/docs/extensions/sphinx-design.rst
@@ -7,8 +7,12 @@ sphinx-design
 
 ``sphinx-design`` extension add many components for Sphinx documentation.
 
-- **Documentation**: https://sphinx-design.readthedocs.io/
-- **Source Code**: https://github.com/executablebooks/sphinx-design
+.. list-table:: Project Information
+
+  * - **Documentation**
+    - https://sphinx-design.readthedocs.io/
+  * - **Source Code**
+    - https://github.com/executablebooks/sphinx-design
 
 Install
 -------

--- a/docs/extensions/sphinx-iconify.rst
+++ b/docs/extensions/sphinx-iconify.rst
@@ -8,8 +8,12 @@ sphinx-iconify
 ``sphinx-iconify`` provides the ``:iconify:`` role, which allows you to use
 the ``<iconify-icon>`` web component
 
-- **Documentation**: https://sphinx-iconify.lepture.com/
-- **Source Code**: https://github.com/lepture/sphinx-iconify
+.. list-table:: Project Information
+
+  * - **Documentation**
+    - https://sphinx-iconify.lepture.com/
+  * - **Source Code**
+    - https://github.com/lepture/sphinx-iconify
 
 Install
 -------

--- a/docs/extensions/sphinx-sqlalchemy.rst
+++ b/docs/extensions/sphinx-sqlalchemy.rst
@@ -5,8 +5,12 @@ sphinx-sqlalchemy
 
 Sphinx extension for documenting SQLAlchemy ORMs.
 
-- **Documentation**: https://sphinx-sqlalchemy.readthedocs.io/
-- **Source Code**: https://github.com/sphinx-extensions2/sphinx-sqlalchemy
+.. list-table:: Project Information
+
+  * - **Documentation**
+    - https://sphinx-sqlalchemy.readthedocs.io/
+  * - **Source Code**
+    - https://github.com/sphinx-extensions2/sphinx-sqlalchemy
 
 Usage
 -----

--- a/docs/extensions/sphinx-tabs.rst
+++ b/docs/extensions/sphinx-tabs.rst
@@ -8,8 +8,12 @@ sphinx-tabs
 sphinx-tab is an extension maintained by Executable Books.
 This extension can create tabbed content.
 
-- **Documentation**: https://sphinx-tabs.readthedocs.io/
-- **Source Code**: https://github.com/executablebooks/sphinx-tabs
+.. list-table:: Project Information
+
+  * - **Documentation**
+    - https://sphinx-tabs.readthedocs.io/
+  * - **Source Code**
+    - https://github.com/executablebooks/sphinx-tabs
 
 Install
 -------

--- a/docs/extensions/sphinx-togglebutton.rst
+++ b/docs/extensions/sphinx-togglebutton.rst
@@ -5,8 +5,12 @@ sphinx-togglebutton
 
 A small sphinx extension to add “toggle button” elements to sections of your page.
 
-- **Documentation**: https://sphinx-togglebutton.readthedocs.io/
-- **Source Code**: https://github.com/executablebooks/sphinx-togglebutton
+.. list-table:: Project Information
+
+  * - **Documentation**
+    - https://sphinx-togglebutton.readthedocs.io/
+  * - **Source Code**
+    - https://github.com/executablebooks/sphinx-togglebutton
 
 Install
 -------


### PR DESCRIPTION
Replace unordered lists with `list-table` for Documentation and Source Code project information across all extension pages.