### PR TITLE
fix: hide breadcrumbs bar on desktop if `hide_breadcrumbs` is true

### DIFF
--- a/src/shibuya/theme/shibuya/components/breadcrumbs.html
+++ b/src/shibuya/theme/shibuya/components/breadcrumbs.html
@@ -5,7 +5,7 @@
 {%- else -%}
   {% set hide_breadcrumbs = False %}
 {%- endif -%}
-<div class="sy-breadcrumbs{% if hide_breadcrumbs %} sy-breadcrumbs-hidden{% endif %}" role="navigation">
+<div class="sy-breadcrumbs{% if hide_breadcrumbs %} xl:hidden{% endif %}" role="navigation">
   <div class="sy-breadcrumbs-inner flex items-center">
     <div class="md:hidden mr-3">
       <button class="js-menu" aria-label="Menu" type="button" aria-controls="lside" aria-expanded="false">

--- a/src/shibuya/theme/shibuya/components/breadcrumbs.html
+++ b/src/shibuya/theme/shibuya/components/breadcrumbs.html
@@ -5,7 +5,7 @@
 {%- else -%}
   {% set hide_breadcrumbs = False %}
 {%- endif -%}
-<div class="sy-breadcrumbs" role="navigation">
+<div class="sy-breadcrumbs{% if hide_breadcrumbs %} sy-breadcrumbs-hidden{% endif %}" role="navigation">
   <div class="sy-breadcrumbs-inner flex items-center">
     <div class="md:hidden mr-3">
       <button class="js-menu" aria-label="Menu" type="button" aria-controls="lside" aria-expanded="false">

--- a/static/css/layout/breadcrumbs.css
+++ b/static/css/layout/breadcrumbs.css
@@ -41,6 +41,9 @@
   .sy-breadcrumbs {
     padding: 0 3rem;
   }
+  .sy-breadcrumbs-hidden {
+    display: none;
+  }
 }
 
 @media (min-width: 768px) {

--- a/static/css/layout/breadcrumbs.css
+++ b/static/css/layout/breadcrumbs.css
@@ -41,9 +41,6 @@
   .sy-breadcrumbs {
     padding: 0 3rem;
   }
-  .sy-breadcrumbs-hidden {
-    display: none;
-  }
 }
 
 @media (min-width: 768px) {


### PR DESCRIPTION
When `hide_breadcrumbs` is true, hide the breadcrumbs bar on desktop, where the menu and left/right sidebars toggle buttons it hosts are hidden anyway. The bar is only needed on smaller screens to host those buttons.