### PR TITLE
fix: offset desktop anchors by breadcrumbs height

### DIFF
--- a/static/css/layout/page.css
+++ b/static/css/layout/page.css
@@ -118,7 +118,12 @@
   .sy-rside .sy-scrollbar {
     max-height: calc(100vh - var(--sy-s-offset-top) - env(safe-area-inset-bottom));
   }
-  .yue * {
+  /* Breadcrumbs hidden: offset anchors below the banner/navbar. */
+  body:has(.sy-breadcrumbs.xl\:hidden) .yue * {
     scroll-margin-top: calc(var(--sy-s-offset-top) + 24px);
+  }
+  /* Breadcrumbs showed: offset anchors below the banner/navbar and the breadcrumbs. */
+  body:not(:has(.sy-breadcrumbs.xl\:hidden)) .yue * {
+    scroll-margin-top: calc(var(--sy-s-offset-top) + var(--sy-s-breadcrumbs-height) + 24px);
   }
 }

--- a/static/css/variables.css
+++ b/static/css/variables.css
@@ -6,6 +6,7 @@
   --sy-f-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
   --sy-s-banner-height: 0rem;
   --sy-s-navbar-height: 56px;
+  --sy-s-breadcrumbs-height: 4rem;
   --sy-s-offset-top: calc(var(--sy-s-navbar-height) + var(--sy-s-banner-height));
 
   --sy-c-divider: var(--gray-4);


### PR DESCRIPTION
Add a `--sy-s-breadcrumbs-height` variable and use `xl:hidden` on `.sy-breadcrumbs` to detect hidden breadcrumbs. The `scroll-margin-top` on desktop layout then reserves the breadcrumbs height only when the breadcrumbs are actually shown.

Close: #143 