### PR TITLE
fix: improve theme-switch button cursor and hit area

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -74,6 +74,10 @@ iconify-icon {
   background-color: currentColor;
 }
 
+.theme-switch {
+  cursor: pointer;
+}
+
 .theme-switch .theme-icon,
 [data-color-mode="auto"] .theme-switch .theme-icon {
   --icon-url: var(--lucide-sun-moon-url);

--- a/static/css/layout/head.css
+++ b/static/css/layout/head.css
@@ -330,4 +330,9 @@
   .sy-head-socials {
     margin-left: 0.5rem;
   }
+
+  .sy-head-actions .theme-switch {
+    height: auto;
+    padding: 0.5rem;
+  }
 }


### PR DESCRIPTION
Improve the navbar theme-switch button affordance:

- Show a `pointer` cursor when hovering the theme-switch button.
- Make the theme-switch click area consistent with the adjacent social icons on desktop.
